### PR TITLE
Minor fixes in C API documentation markup

### DIFF
--- a/docs/dev/training.md
+++ b/docs/dev/training.md
@@ -42,7 +42,7 @@ This reads the downloaded CSV file and creates a new CSV file with inputs and ou
 If you want to try different inputs, you have to program that in Rust ([inputs.rs](../../crates/engine/src/inputs.rs)).
 - Edit the file [`train-on-rollout-data.py`](../../training/src/train-on-rollout-data.py). Make sure the correct model is
 defined, it should be something like `mode = "contact"`.
-- You might want to edit various hyperparameters. Number of epochs, optimizer and and loss function should be ok, but maybe you find better ones.
+- You might want to edit various hyperparameters. Number of epochs, optimizer and loss function should be ok, but maybe you find better ones.
 In any case you should try various learning rates, they have a big impact on the quality of the net.
 - Go to the folder `training` and execute `./src/train-on-rollout-data.py` - this will create a new net. It should take only a minute or two.
 - Check the quality of the net: Edit [`compare-evaluators.rs`](../../crates/coach/src/bin/compare-evaluators.rs) and pick

--- a/docs/user/wildbg-c.md
+++ b/docs/user/wildbg-c.md
@@ -2,35 +2,33 @@
 
 This crate contains a small C library to access some functionality of `wildbg`.
 
-In contrast to the [`web`](../../crates/web/src/) API this library contains less features and needs more manual work to set up. Only use it if you have existing C code and no other way to connect that to `wildbg`.
+In contrast to the [`web`](../../crates/web/src/) API this library offers fewer features and requires more manual work to set up. Only use it if you have existing C code and no other way to connect that to `wildbg`.
 
 You can see the API in the header file: [`crates/wildbg-c/wildbgh.h`](../../crates/wildbg-c/wildbg.h).
 
 ### How to use this library from your C code
 
-Execute the following from the project's root folder:
+Execute the following from the project's root folder.
 
-1. Build the library:
+#### 1. Build the library
 ```
 cargo build --package wildbg-c --lib --release
 ```
-
-2. Copy the library to your C project: (the file might be called `wildbg.dll` or `wildbg.so` depending on your operating system)
-```
+#### 2. Copy the library to your C project
+The shared library file created may be called `wildbg.dll` or `wildbg.so`, depending on your operating system.
+```shell
 cp target/release/libwildbg.a $YOUR_C_PROJECT_FOLDER
 ```
-
-3. Copy the library header (Replace `$YOUR_C_PROJECT_FOLDER` with the correct path):
-```
+#### 3. Copy the library header
+Replace `$YOUR_C_PROJECT_FOLDER` with the correct path):
+```shell
 cp crates/wildbg-c/wildbg.h $YOUR_C_PROJECT_FOLDER
 ```
-
-4. Copy the neural nets:
-```
+#### 4. Copy the neural nets
+```shell
 cp -r neural-nets $YOUR_C_PROJECT_FOLDER
 ```
-
-5. Include the header file in your C file and use `wildbg` from there. Example:
+#### 5. Include the header file in your C file and use `wildbg` from there.
 ```c
 #include <stdio.h>
 #include "wildbg.h"
@@ -55,9 +53,8 @@ int main() {
   wildbg_free(wildbg);  
 }
 ```
-
-6. Don't forget linking the library file into your binary. Example:
-```
+#### 6. Link the library into your binary
+```shell
 cd $YOUR_C_PROJECT_FOLDER
 gcc main.c libwildbg.a
 ```


### PR DESCRIPTION
*    Fixed typo
*    Use section headers in markdown instead of faking a list